### PR TITLE
Versioning the buffertools Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "author": "",
     "license": "BSD",
     "dependencies": {
-        "buffertools": ""
+        "buffertools": "~1"
     }
 }


### PR DESCRIPTION
This was written against `buffertools` version 1, and there has been [at least one breaking change](https://github.com/bnoordhuis/node-buffertools/commit/20b192152d398b2d5b301f00d1e5daa22f6f2e23) since then.

I came across this issue when attempting to use [node-dir-diff](https://github.com/bingomanatee/node-dir-diff) in `content` mode to compare directories.
