### PR TITLE
Prevent duplicate callback on fail

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,8 +51,9 @@ var h2 = function(err,bytesRead,buffer) {
 exports.compare = function(f1,f2,cb) {
   if (f1.size !== f2.size) {
     cb(false);
+  } else {
+    var isEqual = true;
+    var that = {f1:f1,f2:f2,cb:cb};
+    fs.read(f1.fd, f1.b, 0, step, f1.pos, h1.bind(that));
   }
-  var isEqual = true;
-  var that = {f1:f1,f2:f2,cb:cb};
-  fs.read(f1.fd, f1.b, 0, step, f1.pos, h1.bind(that));
 }


### PR DESCRIPTION
I was trying to figure out why after testing a file for expected failure my callback function was getting mysteriously triggered again later on.  I looked here in the source for a clue and noticed the fs.read call in the exported compare function triggers regardless of whether the initial file size check is off or not.  Please commit this correction.  Thanks!
