### PR TITLE
fix: close fds when returning due to different file size

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,8 @@ var doCompare = function(f1, f2, cb, step, bufferSize) {
   assert(step <= bufferSize);
 
   if (f1.size !== f2.size) {
+    fs.closeSync(f1.fd);
+    fs.closeSync(f2.fd);
     return cb(false);
   }
   var isDone = false;


### PR DESCRIPTION
2 days ago I created https://github.com/rook2pawn/node-filecompare/pull/7  
I closed the old PR because I thought it didn't completely fix the issue #4 as I ran into another problem related to https://github.com/nodejs/node/pull/30837

But it seems to be working now.